### PR TITLE
Added Hugo website configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Some preset for the settings of the plugin.
 
 ## Presets list
 - [mkdocs.json](./presets/mkdocs.json): For [Obsidian Mkdocs Publisher]([https://obsidian-publisher.netlify.app/template/](https://obsidian-publisher.netlify.app/plugin/example/configuration%20example/#mkdocs-publisher)https://obsidian-publisher.netlify.app/plugin/example/configuration%20example/#mkdocs-publisher)
+- [hugo.json](./presets/hugo.json): For [Hugo](https://gohugo.io/) website configuration, including [link conversion](https://gohugo.io/content-management/cross-references/) from Wikilinks to Hugo format.

--- a/presets/hugo.json
+++ b/presets/hugo.json
@@ -1,0 +1,76 @@
+{
+    "github": {
+      "branch": "main",
+      "automaticallyMergePR": true,
+      "api": {
+        "tiersForApi": "Github Free/Pro/Team (default)",
+        "hostname": ""
+      },
+      "workflow": {
+        "name": "",
+        "commitMessage": "[PUBLISHER] MERGE"
+      },
+      "tokenPath": ".obsidian/plugins/obsidian-mkdocs-publisher/env",
+      "verifiedRepo": true
+    },
+    "upload": {
+      "behavior": "fixed",
+      "subFolder": "",
+      "defaultName": "content/post",
+      "rootFolder": "",
+      "yamlFolderKey": "",
+      "frontmatterTitle": {
+        "enable": true,
+        "key": "title"
+      },
+      "replaceTitle": [],
+      "autoclean": {
+        "enable": false,
+        "excluded": [
+          "docs/assets/js",
+          "docs/assets/meta",
+          "docs/assets/css",
+          "tags.md",
+          "graph.md"
+        ]
+      },
+      "folderNote": {
+        "enable": true,
+        "rename": "index.md"
+      },
+      "metadataExtractorPath": "",
+      "replacePath": []
+    },
+    "conversion": {
+      "hardbreak": false,
+      "dataview": false,
+      "censorText": [
+        {
+          "entry": "/!\\[\\[([^[\\]]+)\\]\\]/gi",
+          "replace": "![$1](/images/$1)",
+          "after": false
+        },
+        {
+          "entry": "/\\[\\[([^|\\]]+)\\|([^\\]]+)\\]\\]|\\[\\[([^\\]|]+)\\]\\]/gi",
+          "replace": "[$2$3]({{< ref \"$1$3\" >}})",
+          "after": false
+        }
+      ],
+      "tags": {
+        "inline": false,
+        "exclude": [],
+        "fields": []
+      },
+      "links": {
+        "internal": false,
+        "unshared": false,
+        "wiki": false
+      }
+    },
+    "embed": {
+      "attachments": true,
+      "keySendFile": [],
+      "notes": true,
+      "folder": "content/images"
+    }
+  }


### PR DESCRIPTION
Added Hugo website configuration using regex link conversion
from wikilinks to hugo format and from embedded images to hugo format.

[Discussion 189](https://github.com/orgs/ObsidianPublisher/discussions/189)

[Images conversion](https://regex101.com/r/nTfbd9/1) : 
`/!\[\[([^[\]]+)\]\]/gi` -> `![$1](/images/$1)`

[Wikilinks conversion](https://regex101.com/r/F8ylWa/1) : 
`/\[\[([^|\]]+)\|([^\]]+)\]\]|\[\[([^\]|]+)\]\]/gi` -> `[$2$3]({{< ref "$1$3" >}})`